### PR TITLE
feat: maintain non-ast tokens on round trip

### DIFF
--- a/rewriter/options.py
+++ b/rewriter/options.py
@@ -4,6 +4,7 @@ from typing import Protocol
 
 class Options(Protocol):
     filename: str
+    source: str
     dry_run: bool
     print_stats: bool
 

--- a/rewriter/parser.py
+++ b/rewriter/parser.py
@@ -1,15 +1,51 @@
 from ast import Module, parse, unparse
+from difflib import Differ
+
+from black import format_str
+from black.mode import Mode, TargetVersion
 
 from rewriter.options import Options
 
 
 def parse_tree(opts: Options) -> Module:
     with open(opts.filename) as f:
-        source = f.read()
-    return parse(source, opts.filename)
+        opts.source = f.read()
+    return parse(opts.source, opts.filename)
 
 
-def unparse_tree(opts: Options, tree: Module) -> None:
+def unparse_tree(opts: Options, tree: Module) -> str:
     result = unparse(tree)
-    with open(opts.filename, "w") as f:
-        f.write(result)
+    reformatted = reformat(result)
+    final = merge_new_code(opts, reformatted)
+
+    if not opts.dry_run:
+        with open(opts.filename, "w") as f:
+            f.write(final)
+    return final
+
+
+def merge_new_code(opts: Options, result: str) -> str:
+    result_lines = result.strip().splitlines()
+    original = opts.source.splitlines()
+
+    final: list[str] = []
+    differ = Differ()
+    for diff in differ.compare(original, result_lines):
+        diff_type = diff[0]
+        line = diff[2:]
+
+        if diff_type in (" ", "+"):
+            final.append(f"{line}\n")
+        elif diff_type == "-" and is_empty_or_comment(line):
+            final.append(f"{line}\n")
+
+    return "".join(final)
+
+
+def is_empty_or_comment(line: str) -> bool:
+    return not line or line.lstrip().startswith("#")
+
+
+def reformat(code: str) -> str:
+    black_mode = Mode(target_versions={TargetVersion.PY37}, line_length=100)
+    return format_str(code, mode=black_mode)

--- a/tests/walker_test.py
+++ b/tests/walker_test.py
@@ -23,6 +23,7 @@ def test_func_definition() -> None:
     source = format_str(
         """
         def test(x):
+            # TODO: implement
             pass
         """
     )
@@ -30,6 +31,7 @@ def test_func_definition() -> None:
         """
         def test(x: Any) -> Any:
 
+            # TODO: implement
             pass
         """
     ).lstrip()
@@ -41,6 +43,7 @@ def test_class_definition() -> None:
     source = format_str(
         """
         class Test:
+            # TODO: implement
 
             def __init__(self, x):
                 pass
@@ -52,6 +55,7 @@ def test_class_definition() -> None:
     expected = format_str(
         """
         class Test:
+            # TODO: implement
 
             def __init__(self, x: Any) -> None:
                 pass

--- a/tests/walker_test.py
+++ b/tests/walker_test.py
@@ -3,20 +3,20 @@ from textwrap import dedent
 from unittest.mock import Mock
 
 from rewriter.options import Options
+from rewriter.parser import unparse_tree
 from rewriter.walker import Walker
 
 
 def format_str(source: str) -> str:
-    return dedent(source).strip()
+    return dedent(source)
 
 
 def generate_new_source(source: str) -> str:
-    mock_opts = Mock(spec=Options, filename="test.py")
+    mock_opts = Mock(spec=Options, filename="test.py", source=source, dry_run=True)
     tree = ast.parse(source)
     walker = Walker(mock_opts, tree)
     walker.walk()
-    print(walker.edges)
-    return ast.unparse(tree)
+    return unparse_tree(mock_opts, tree)
 
 
 def test_func_definition() -> None:
@@ -29,9 +29,10 @@ def test_func_definition() -> None:
     expected = format_str(
         """
         def test(x: Any) -> Any:
+
             pass
         """
-    )
+    ).lstrip()
 
     assert generate_new_source(source) == expected
 


### PR DESCRIPTION
The `ast` module does not maintain formatting or any non-functional ast nodes (ie. comments).  This will bring back formatting and comments.